### PR TITLE
Changes about the MeiliSearch's next release (v1.0.1)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 lol
 
-This package only guarantees the compatibility with the [version v0.15.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.15.0).
+This package only guarantees the compatibility with the [version v1.0.1 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v1.0.1).
 
 
 titi


### PR DESCRIPTION
- [x] Update README

This PR:
- gathers the changes relative to the next release of MeiliSearch (v1.0.1) so that this package is ready when the official release is out.
- should work locally with the [latest prerelease of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases).
- might eventually fail until the MeiliSearch v1.0.1 is out.

⚠️ This PR should NOT be merged until the MeiliSearch's release v1.0.1 is out.