### PR TITLE
Changes about the MeiliSearch's next release (v0.16.0)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
 lol2
 
-This package only guarantees the compatibility with the [version v0.15.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.15.0).
+This package only guarantees the compatibility with the [version v0.16.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.16.0).
 


### PR DESCRIPTION
Related to this issue: https://github.com/meilisearch/integration-guides/issues/...

- [x] Update README
- [ ] ...
- [ ] ...

This PR:
- gathers the changes related to the next release of MeiliSearch (v0.16.0) so that this package is ready when the official release is out.
- should pass the tests against the [latest pre-release of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases). This should be tested locally.
- might eventually fail until the MeiliSearch v0.16.0 is out.

⚠️ This PR should NOT be merged until the MeiliSearch's next release (v0.16.0) is out.